### PR TITLE
feat: implement dynamic API URL configuration with Firebase Remote Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ secret.properties
 /app/release/
 /app/google-services.json
 certs/release.keystore
+.claude
+CLAUDE.md

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,11 +57,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
@@ -105,6 +105,7 @@ dependencies {
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.perf)
+    implementation(libs.firebase.config)
     implementation(libs.playServices.location)
     implementation(libs.maps)
     implementation(libs.credentials)
@@ -132,6 +133,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.strikt)
     testImplementation(libs.coroutines.testing)
+    testImplementation(libs.mockito.kotlin)
 }
 
 secrets {

--- a/app/src/main/java/com/sloy/sevibus/SevApplication.kt
+++ b/app/src/main/java/com/sloy/sevibus/SevApplication.kt
@@ -5,11 +5,16 @@ import com.sloy.sevibus.infrastructure.AndroidLogger
 import com.sloy.sevibus.infrastructure.BuildVariantDI
 import com.sloy.sevibus.infrastructure.DI
 import com.sloy.sevibus.infrastructure.SevLogger
+import com.sloy.sevibus.infrastructure.config.RemoteConfigService
+import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
 class SevApplication : Application() {
+
+    private val remoteConfigService: RemoteConfigService by inject()
+    
     override fun onCreate() {
         super.onCreate()
         SevLogger.setLogger(AndroidLogger())
@@ -18,5 +23,7 @@ class SevApplication : Application() {
             androidContext(this@SevApplication)
             modules(DI.viewModelModule, DI.dataModule, DI.infrastructureModule, BuildVariantDI.module)
         }
+
+        remoteConfigService.initialize()
     }
 }

--- a/app/src/main/java/com/sloy/sevibus/infrastructure/DI.kt
+++ b/app/src/main/java/com/sloy/sevibus/infrastructure/DI.kt
@@ -128,7 +128,7 @@ object DI {
         single<SevibusApi> {
             val retrofit = Retrofit.Builder()
                 .client(get())
-                .baseUrl("https://base.url/api/")
+                .baseUrl("${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/")
                 .addConverterFactory(
                     json.asConverterFactory("application/json; charset=UTF-8".toMediaType())
                 )
@@ -140,7 +140,7 @@ object DI {
                 .client(get<OkHttpClient>().newBuilder().apply {
                     interceptors().add(0, FirebaseAuthHeaderInterceptor())
                 }.build())
-                .baseUrl("https://base.url/api/")
+                .baseUrl("${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/")
                 .addConverterFactory(
                     json.asConverterFactory("application/json; charset=UTF-8".toMediaType())
                 )

--- a/app/src/main/java/com/sloy/sevibus/infrastructure/config/ApiConfigurationManager.kt
+++ b/app/src/main/java/com/sloy/sevibus/infrastructure/config/ApiConfigurationManager.kt
@@ -1,0 +1,33 @@
+package com.sloy.sevibus.infrastructure.config
+
+import com.sloy.sevibus.infrastructure.BuildVariant
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class ApiConfigurationManager {
+
+    companion object {
+        private const val DEFAULT_DEBUG_URL = "https://ui6647hi28.execute-api.eu-south-2.amazonaws.com/dev/"
+        private const val DEFAULT_RELEASE_URL = "https://ldzu622p0l.execute-api.eu-south-2.amazonaws.com/prod/"
+    }
+
+    private val apiUrl = MutableStateFlow(getDefaultApiUrl())
+
+    fun getCurrentApiUrl(): String = apiUrl.value
+
+    fun updateApiUrl(newUrl: String) {
+        if (newUrl.isNotBlank() && newUrl != apiUrl.value) {
+            apiUrl.value = ensureTrailingSlash(newUrl)
+        }
+    }
+
+    private fun getDefaultApiUrl(): String {
+        return when (BuildVariant.current()) {
+            BuildVariant.DEBUG -> DEFAULT_DEBUG_URL
+            BuildVariant.RELEASE -> DEFAULT_RELEASE_URL
+        }
+    }
+
+    private fun ensureTrailingSlash(url: String): String {
+        return if (url.endsWith("/")) url else "$url/"
+    }
+}

--- a/app/src/main/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptor.kt
+++ b/app/src/main/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptor.kt
@@ -1,0 +1,23 @@
+package com.sloy.sevibus.infrastructure.config
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class DynamicApiUrlInterceptor(
+    private val configurationManager: ApiConfigurationManager
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val currentApiUrl = configurationManager.getCurrentApiUrl()
+
+        val baseUrl: String = originalRequest.url.toUrl().toString()
+        val newUrl = baseUrl.replace("https://base.url/", currentApiUrl)
+
+        val newRequest = originalRequest.newBuilder()
+            .url(newUrl)
+            .build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/sloy/sevibus/infrastructure/config/RemoteConfigService.kt
+++ b/app/src/main/java/com/sloy/sevibus/infrastructure/config/RemoteConfigService.kt
@@ -1,0 +1,82 @@
+package com.sloy.sevibus.infrastructure.config
+
+import com.google.firebase.remoteconfig.ConfigUpdate
+import com.google.firebase.remoteconfig.ConfigUpdateListener
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigException
+import com.google.firebase.remoteconfig.remoteConfigSettings
+import com.sloy.sevibus.infrastructure.SevLogger
+
+class RemoteConfigService(
+    private val apiConfigurationManager: ApiConfigurationManager
+) {
+
+    companion object {
+        private const val API_URL_KEY = "api_url"
+        private const val FETCH_TIMEOUT_SECONDS = 60L
+        private const val MIN_FETCH_INTERVAL_SECONDS = 3600L // 1 hour
+    }
+
+    private val remoteConfig = FirebaseRemoteConfig.getInstance()
+
+    fun initialize() {
+        setupRemoteConfig()
+        setupDefaultValues()
+        setupConfigUpdateListener()
+        fetchAndActivate()
+    }
+
+    private fun setupRemoteConfig() {
+        val configSettings = remoteConfigSettings {
+            minimumFetchIntervalInSeconds = MIN_FETCH_INTERVAL_SECONDS
+            fetchTimeoutInSeconds = FETCH_TIMEOUT_SECONDS
+        }
+        remoteConfig.setConfigSettingsAsync(configSettings)
+    }
+
+    private fun setupDefaultValues() {
+        val defaults = mapOf(API_URL_KEY to apiConfigurationManager.getCurrentApiUrl())
+        remoteConfig.setDefaultsAsync(defaults)
+    }
+
+    private fun setupConfigUpdateListener() {
+        remoteConfig.addOnConfigUpdateListener(object : ConfigUpdateListener {
+            override fun onUpdate(configUpdate: ConfigUpdate) {
+                SevLogger.logD("Config update received: ${configUpdate.updatedKeys}")
+
+                remoteConfig.activate().addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        val newApiUrl = remoteConfig.getString(API_URL_KEY)
+                        SevLogger.logD("Updating API URL to: $newApiUrl")
+                        apiConfigurationManager.updateApiUrl(newApiUrl)
+                    } else {
+                        task.exception?.let {
+                            SevLogger.logE(it, "Failed to activate config update")
+                        }
+                    }
+                }
+            }
+
+            override fun onError(error: FirebaseRemoteConfigException) {
+                SevLogger.logE(error, "Config update listener failed")
+            }
+        })
+    }
+
+    private fun fetchAndActivate() {
+        remoteConfig.fetchAndActivate().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val updated = task.result
+                SevLogger.logD("Config fetch successful. Updated: $updated")
+
+                val newApiUrl = remoteConfig.getString(API_URL_KEY)
+                apiConfigurationManager.updateApiUrl(newApiUrl)
+            } else {
+                task.exception?.let {
+                    SevLogger.logE(it, "Config fetch failed")
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/test/java/com/sloy/sevibus/data/api/FakeSevibusApi.kt
+++ b/app/src/test/java/com/sloy/sevibus/data/api/FakeSevibusApi.kt
@@ -2,10 +2,13 @@ package com.sloy.sevibus.data.api
 
 import com.sloy.sevibus.data.api.model.BusArrivalDto
 import com.sloy.sevibus.data.api.model.BusDto
+import com.sloy.sevibus.data.api.model.CardInfoDto
+import com.sloy.sevibus.data.api.model.CardTransactionDto
 import com.sloy.sevibus.data.api.model.LineDto
 import com.sloy.sevibus.data.api.model.PathDto
 import com.sloy.sevibus.data.api.model.RouteDto
 import com.sloy.sevibus.data.api.model.StopDto
+import com.sloy.sevibus.domain.model.CardId
 import com.sloy.sevibus.domain.model.RouteId
 import com.sloy.sevibus.domain.model.StopId
 import kotlinx.coroutines.CompletableDeferred
@@ -22,6 +25,8 @@ class FakeSevibusApi : SevibusApi {
     var arrivalsResponse: List<BusArrivalDto> = emptyList()
     var pathResponse: PathDto? = null
     var busesResponse: List<BusDto> = emptyList()
+    var cardInfoResponse: CardInfoDto? = null
+    var cardTransactionsResponse: List<CardTransactionDto> = emptyList()
 
     private var waitForResponses = false
     private var latch = CompletableDeferred<Unit>()
@@ -100,5 +105,15 @@ class FakeSevibusApi : SevibusApi {
         getBusesCount++
         awaitLatch()
         return@withContext busesResponse
+    }
+
+    override suspend fun getCardInfo(card: CardId): CardInfoDto = withContext(Dispatchers.IO) {
+        awaitLatch()
+        return@withContext cardInfoResponse!!
+    }
+
+    override suspend fun getCardTransactions(card: CardId): List<CardTransactionDto> = withContext(Dispatchers.IO) {
+        awaitLatch()
+        return@withContext cardTransactionsResponse
     }
 }

--- a/app/src/test/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptorTest.kt
+++ b/app/src/test/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptorTest.kt
@@ -1,0 +1,185 @@
+package com.sloy.sevibus.infrastructure.config
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.whenever
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class DynamicApiUrlInterceptorTest {
+
+    private lateinit var apiConfigurationManager: ApiConfigurationManager
+    private lateinit var interceptor: DynamicApiUrlInterceptor
+    private lateinit var mockChain: Interceptor.Chain
+    private lateinit var mockResponse: Response
+
+    @Before
+    fun setup() {
+        apiConfigurationManager = ApiConfigurationManager()
+        interceptor = DynamicApiUrlInterceptor(apiConfigurationManager)
+        mockChain = mock()
+        mockResponse = mock()
+    }
+
+    @Test
+    fun `should replace base URL with configured API URL`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/api/"
+        val expectedUrl = "https://api.example.com/v1/api/"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should replace URL and preserve endpoint path`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/admin/health"
+        val expectedUrl = "https://api.example.com/v1/admin/health"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should replace URL and preserve nested endpoint paths`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/api/stops/123/arrivals"
+        val expectedUrl = "https://api.example.com/v1/api/stops/123/arrivals"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should preserve query parameters`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/api/search?q=test&limit=10"
+        val expectedUrl = "https://api.example.com/v1/api/search?q=test&limit=10"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should handle different configured URL schemes`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/test"
+        val expectedUrl = "https://api.example.com/v1/test"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should handle different configured URL ports`() {
+        val substituteUrl = "https://api.example.com:8080/v2/"
+        val originalUrl = "https://base.url/endpoint"
+        val expectedUrl = "https://api.example.com:8080/v2/endpoint"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should handle configured URL without trailing slash`() {
+        val substituteUrl = "https://api.example.com/v1"
+        val originalUrl = "https://base.url/health"
+        val expectedUrl = "https://api.example.com/v1/health"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should handle configured URL with multiple path segments`() {
+        val substituteUrl = "https://api.example.com/v1/api/sevibus/"
+        val originalUrl = "https://base.url/lines"
+        val expectedUrl = "https://api.example.com/v1/api/sevibus/lines"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should handle request to root path`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/"
+        val expectedUrl = "https://api.example.com/v1/"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should preserve headers and method`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://base.url/data"
+        val expectedUrl = "https://api.example.com/v1/data"
+
+        // Given
+        apiConfigurationManager.updateApiUrl(substituteUrl)
+        val originalRequest = Request.Builder()
+            .url(originalUrl)
+            .header("Authorization", "Bearer token123")
+            .header("Content-Type", "application/json")
+            .post(okhttp3.RequestBody.create(null, "{}"))
+            .build()
+
+        val expectedHttpUrl = expectedUrl.toHttpUrl()
+
+        whenever(mockChain.request()).thenReturn(originalRequest)
+        whenever(mockChain.proceed(any<Request>())).thenReturn(mockResponse)
+
+        // When
+        interceptor.intercept(mockChain)
+
+        // Then
+        val requestCaptor = argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+        val capturedRequest = requestCaptor.firstValue
+        expectThat(capturedRequest.url).isEqualTo(expectedHttpUrl)
+        expectThat(capturedRequest.method).isEqualTo("POST")
+        expectThat(capturedRequest.header("Authorization")).isEqualTo("Bearer token123")
+        expectThat(capturedRequest.header("Content-Type")).isEqualTo("application/json")
+    }
+
+    @Test
+    fun `should work with real AWS API Gateway URLs`() {
+        val substituteUrl = "https://abc123.execute-api.eu-west-1.amazonaws.com/prod/"
+        val originalUrl = "https://base.url/api/stops/456"
+        val expectedUrl = "https://abc123.execute-api.eu-west-1.amazonaws.com/prod/api/stops/456"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    @Test
+    fun `should not modify request if URL does not match base URL pattern`() {
+        val substituteUrl = "https://api.example.com/v1/"
+        val originalUrl = "https://different.api/endpoint"
+        val expectedUrl = "https://different.api/endpoint"
+
+        testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
+    }
+
+    private fun testUrlReplacement(
+        substituteUrl: String,
+        originalUrl: String,
+        expectedUrl: String
+    ) {
+        // Given
+        apiConfigurationManager.updateApiUrl(substituteUrl)
+        val originalRequest = Request.Builder().url(originalUrl).build()
+        val expectedHttpUrl = expectedUrl.toHttpUrl()
+
+        whenever(mockChain.request()).thenReturn(originalRequest)
+        whenever(mockChain.proceed(any<Request>())).thenReturn(mockResponse)
+
+        // When
+        interceptor.intercept(mockChain)
+
+        // Then
+        val requestCaptor = argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+        expectThat(requestCaptor.firstValue.url).isEqualTo(expectedHttpUrl)
+    }
+}

--- a/app/src/test/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptorTest.kt
+++ b/app/src/test/java/com/sloy/sevibus/infrastructure/config/DynamicApiUrlInterceptorTest.kt
@@ -32,7 +32,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should replace base URL with configured API URL`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/api/"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/"
         val expectedUrl = "https://api.example.com/v1/api/"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -41,7 +41,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should replace URL and preserve endpoint path`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/admin/health"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}admin/health"
         val expectedUrl = "https://api.example.com/v1/admin/health"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -50,7 +50,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should replace URL and preserve nested endpoint paths`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/api/stops/123/arrivals"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/stops/123/arrivals"
         val expectedUrl = "https://api.example.com/v1/api/stops/123/arrivals"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -59,7 +59,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should preserve query parameters`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/api/search?q=test&limit=10"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/search?q=test&limit=10"
         val expectedUrl = "https://api.example.com/v1/api/search?q=test&limit=10"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -68,7 +68,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should handle different configured URL schemes`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/test"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}test"
         val expectedUrl = "https://api.example.com/v1/test"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -77,7 +77,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should handle different configured URL ports`() {
         val substituteUrl = "https://api.example.com:8080/v2/"
-        val originalUrl = "https://base.url/endpoint"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}endpoint"
         val expectedUrl = "https://api.example.com:8080/v2/endpoint"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -86,7 +86,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should handle configured URL without trailing slash`() {
         val substituteUrl = "https://api.example.com/v1"
-        val originalUrl = "https://base.url/health"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}health"
         val expectedUrl = "https://api.example.com/v1/health"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -95,7 +95,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should handle configured URL with multiple path segments`() {
         val substituteUrl = "https://api.example.com/v1/api/sevibus/"
-        val originalUrl = "https://base.url/lines"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}lines"
         val expectedUrl = "https://api.example.com/v1/api/sevibus/lines"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -104,7 +104,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should handle request to root path`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}"
         val expectedUrl = "https://api.example.com/v1/"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)
@@ -113,7 +113,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should preserve headers and method`() {
         val substituteUrl = "https://api.example.com/v1/"
-        val originalUrl = "https://base.url/data"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}data"
         val expectedUrl = "https://api.example.com/v1/data"
 
         // Given
@@ -146,7 +146,7 @@ class DynamicApiUrlInterceptorTest {
     @Test
     fun `should work with real AWS API Gateway URLs`() {
         val substituteUrl = "https://abc123.execute-api.eu-west-1.amazonaws.com/prod/"
-        val originalUrl = "https://base.url/api/stops/456"
+        val originalUrl = "${DynamicApiUrlInterceptor.BASE_URL_PLACEHOLDER}api/stops/456"
         val expectedUrl = "https://abc123.execute-api.eu-west-1.amazonaws.com/prod/api/stops/456"
 
         testUrlReplacement(substituteUrl, originalUrl, expectedUrl)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ coreKtx = "1.16.0"
 firebaseBom = "33.15.0"
 junit = "4.13.2"
 strikt = "0.35.1"
+mockito = "5.4.0"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.00"
@@ -67,6 +68,7 @@ firebase-auth-ktx = { module = "com.google.firebase:firebase-auth" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
+firebase-config = { module = "com.google.firebase:firebase-config" }
 
 maps = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 maps-secrets-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "mapsecrets" }
@@ -91,6 +93,7 @@ reorderable = { module = "sh.calvin.reorderable:reorderable", version = "2.5.1" 
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 strikt = { module = "io.strikt:strikt-core", version.ref = "strikt" }
+mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito" }
 
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashScreen" }
 


### PR DESCRIPTION
## Summary
- Add Firebase Remote Config integration for dynamic API URL management
- Implement DynamicApiUrlInterceptor for runtime URL replacement
- Add comprehensive unit tests with Mockito for interceptor functionality
- Upgrade to mockito-kotlin 5.4.0 and remove unnecessary mockito-core dependency

## Technical Changes
- **ApiConfigurationManager**: Manages current API URL with default build-variant-specific URLs
- **DynamicApiUrlInterceptor**: OkHttp interceptor that replaces placeholder base URLs with configured URLs
- **RemoteConfigService**: Firebase Remote Config integration with real-time updates and error handling
- **Comprehensive unit tests**: 12 test scenarios covering URL transformation, query parameters, headers preservation, and edge cases

## Test Coverage
- URL replacement with different substitute URLs (AWS API Gateway, custom domains, ports)
- Query parameter and header preservation
- Edge cases (trailing slashes, multiple path segments, non-matching URLs)
- Proper mocking with Mockito to test input/output behavior

🤖 Generated with [Claude Code](https://claude.ai/code)